### PR TITLE
Fix up contextmenu link issue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -78,6 +78,7 @@ urlPrefix: https://w3c.github.io/paint-timing/; spec: PAINT-TIMING;
 urlPrefix: https://w3c.github.io/uievents/; spec: UIEVENTS;
     type: event; url: #event-type-auxclick; text: auxclick;
     type: event; url: #event-type-click; text: click;
+    type: event; url: #event-type-contextmenu; text: contextmenu;
     type: event; url: #event-type-dblclick; text: dblclick;
     type: event; url: #event-type-mousedown; text: mousedown;
     type: event; url: #event-type-mouseenter; text: mouseenter;


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2022, 1:25 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fevent-timing%2F69bee7c2e80a384b05861af077d46827b65af630%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 3, in 
    from bikeshed import cli
  File "/sites/api.csswg.org/bikeshed/bikeshed/__init__.py", line 65, in 
    from . import config  # noqa: E402
  File "/sites/api.csswg.org/bikeshed/bikeshed/config/__init__.py", line 2, in 
    from .dfnTypes import (
  File "/sites/api.csswg.org/bikeshed/bikeshed/config/dfnTypes.py", line 4, in 
    from .. import t
  File "/sites/api.csswg.org/bikeshed/bikeshed/t.py", line 6, in 
    from typing import (
ImportError: cannot import name 'Literal' from 'typing' (/usr/local/lib/python3.7/typing.py)
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/event-timing%23116.)._
</details>
