### PR TITLE
Update spec URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Group: webperf
 Level: 1
 Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org
         Tim Dresser, Google https://google.com, tdresser@chromium.org
-URL: https://wicg.github.io/event-timing
+URL: https://w3c.github.io/event-timing
 Repository: https://github.com/WICG/event-timing
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/event-timing
 Abstract: This document defines an API that provides web page authors with insights into the latency of certain events triggered by user interactions.


### PR DESCRIPTION
The current URL just redirects to `w3c.github.io`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/queengooborg/event-timing/pull/119.html" title="Last updated on Apr 28, 2022, 6:54 AM UTC (4537f63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/event-timing/119/6354f61...queengooborg:4537f63.html" title="Last updated on Apr 28, 2022, 6:54 AM UTC (4537f63)">Diff</a>