### PR TITLE
Add final slash to ED URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ Level: none
 Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org, w3cid 103755
         Tim Dresser, Google https://google.com, tdresser@chromium.org, w3cid 68214
 
-URL: https://w3c.github.io/event-timing
+URL: https://w3c.github.io/event-timing/
 TR: https://www.w3.org/TR/event-timing/
 Repository: https://github.com/WICG/event-timing
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/event-timing


### PR DESCRIPTION
Minor update to save a 301 Permanent redirect when someone wants to access the ED from the TR document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/event-timing/pull/120.html" title="Last updated on Jun 9, 2022, 9:03 AM UTC (cd5b575)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/event-timing/120/7412d57...tidoust:cd5b575.html" title="Last updated on Jun 9, 2022, 9:03 AM UTC (cd5b575)">Diff</a>